### PR TITLE
Add fake try-on service with email summary support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,11 @@ SECRET_KEY=your-secret-key-change-in-production
 # Brand Selection (optional)
 # Leave empty to show all brands, or specify a brand name to filter products
 DEFAULT_BRAND=
+
+# Email (optionnel)
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USERNAME=
+SMTP_PASSWORD=
+SMTP_SENDER=no-reply@example.com
+SMTP_USE_TLS=true

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A modern virtual try-on application built with React, FastAPI, and Docker. This 
 - **Image Capture**: Upload or capture selfie photos for virtual try-on
 - **Virtual Fitting**: AI-powered virtual try-on with realistic results
 - **Interactive Results**: Like, download, and share virtual fitting results
+- **Email Summary**: Receive a recap email of generated looks with product descriptions
 - **Responsive Design**: Modern UI that works on all devices
 - **Brand Filtering**: Filter products by specific brands via environment variables
 
@@ -143,6 +144,12 @@ uvicorn app.main:app --reload
 | `GEMINI_API_KEY` | Google Gemini API key | Yes |
 | `SECRET_KEY` | JWT secret key | Yes |
 | `DEFAULT_BRAND` | Default brand filter (optional) | No |
+| `SMTP_HOST` | SMTP server host for email summaries | No |
+| `SMTP_PORT` | SMTP server port | No (default 587) |
+| `SMTP_USERNAME` | SMTP username if authentication is required | No |
+| `SMTP_PASSWORD` | SMTP password if authentication is required | No |
+| `SMTP_SENDER` | Email sender address for summaries | No |
+| `SMTP_USE_TLS` | Enable STARTTLS when sending emails | No (default `true`) |
 
 ## 📱 API Endpoints
 

--- a/backend/app/api/tryon.py
+++ b/backend/app/api/tryon.py
@@ -1,15 +1,15 @@
-from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Form
-from typing import Optional, Dict, Any
-from app.schemas.tryon import TryOnRequest, TryOnResponse, TryOnSessionResponse, ProductInfo
+import uuid
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
+from app.schemas.tryon import TryOnRequest, TryOnResponse, TryOnSessionResponse
 from app.services.tryon_service import TryOnService
 from app.services.supabase_service import SupabaseService
 from app.api.auth import get_current_user_optional
-import asyncio
-import uuid
 
 router = APIRouter()
 
-session_storage: Dict[str, Dict[str, Any]] = {}
+tryon_service = TryOnService()
 
 @router.post("/", response_model=TryOnResponse)
 async def create_try_on(
@@ -18,23 +18,12 @@ async def create_try_on(
 ):
     """Create a new virtual try-on session"""
     try:
-        tryon_service = TryOnService()
-        
-        session_id = request.session_id or str(uuid.uuid4())
-        session_storage[session_id] = {
-            "product_ids": request.product_ids,
-            "products_info": request.products_info,
-            "person_image_url": request.person_image_url,
-            "created_at": asyncio.get_event_loop().time()
-        }
-        
         response = await tryon_service.process_try_on(request)
-        asyncio.create_task(simulate_try_on_processing(session_id, request))
-        
         return response
-        
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
 
 @router.post("/upload", response_model=dict)
 async def upload_person_image(
@@ -76,9 +65,7 @@ async def get_try_on_status_no_slash(
 ):
     """Get virtual try-on status (without slash)"""
     try:
-        tryon_service = TryOnService()
         result = await tryon_service.get_try_on_status(session_id)
-        
         return TryOnSessionResponse(
             session_id=result["session_id"],
             status=result["status"],
@@ -86,9 +73,10 @@ async def get_try_on_status_no_slash(
             message=result.get("message", ""),
             error_message=result.get("error_message")
         )
-        
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Session not found")
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
 
 @router.get("/{session_id}/status/", response_model=TryOnSessionResponse)
 async def get_try_on_status(
@@ -97,54 +85,15 @@ async def get_try_on_status(
 ):
     """Get virtual try-on status"""
     try:
-        await asyncio.sleep(2)
-        
-        session_data = session_storage.get(session_id)
-        if not session_data:
-            raise HTTPException(status_code=404, detail="Session not found")
-        
-        product_ids = session_data["product_ids"]
-        products_info = session_data.get("products_info", [])
-        
-        fake_results = {}
-        
-        for i, product_id in enumerate(product_ids):
-            product_info = None
-            if products_info:
-                for p_info in products_info:
-                    if p_info.id == product_id:
-                        product_info = p_info
-                        break
-            
-            if product_info:
-                product_name = product_info.name
-                product_image = product_info.image_url
-                
-                fake_results[f"product_{product_id}"] = {
-                    "product_id": product_id,
-                    "product_name": product_name,
-                    "result_image": product_image,
-                    "status": "success"
-                }
-            else:
-                fake_results[f"product_{product_id}"] = {
-                    "product_id": product_id,
-                    "product_name": f"Selected Item #{product_id}",
-                    "result_image": "https://via.placeholder.com/400x600?text=Product+Missing",
-                    "status": "success"
-                }
-        
+        result = await tryon_service.get_try_on_status(session_id)
         return TryOnSessionResponse(
-            session_id=session_id,
-            status="completed",
-            results=fake_results,
-            message=f"Virtual try-on completed successfully - {len(fake_results)} result(s)"
+            session_id=result["session_id"],
+            status=result["status"],
+            results=result.get("results"),
+            message=result.get("message", ""),
+            error_message=result.get("error_message")
         )
-        
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
-
-async def simulate_try_on_processing(session_id: str, request: TryOnRequest):
-    """Simulate virtual try-on processing in background"""
-    processing_time = 2 + len(request.product_ids) * 0.5
-    await asyncio.sleep(processing_time)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Session not found")
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -18,9 +18,17 @@ class Settings(BaseSettings):
     
     # CORS
     frontend_url: str = "http://localhost:3000"
-    
+
     # Brand Selection
     default_brand: Optional[str] = None
+
+    # SMTP / Email
+    smtp_host: Optional[str] = None
+    smtp_port: int = 587
+    smtp_username: Optional[str] = None
+    smtp_password: Optional[str] = None
+    smtp_sender: Optional[str] = None
+    smtp_use_tls: bool = True
     
     # App
     app_name: str = "VTON Demo Professional"

--- a/backend/app/schemas/tryon.py
+++ b/backend/app/schemas/tryon.py
@@ -1,21 +1,25 @@
-from pydantic import BaseModel
-from typing import Dict, Any, Optional, List
+from pydantic import BaseModel, EmailStr
+from typing import Dict, Optional, List
 
 class ProductInfo(BaseModel):
     id: int
     name: str
     price: str
     image_url: str
+    description: Optional[str] = None
 
 class TryOnRequest(BaseModel):
     person_image_url: str
     product_ids: List[int]
     products_info: Optional[List[ProductInfo]] = None  # Informations des produits sélectionnés
     session_id: Optional[str] = None
+    email: Optional[EmailStr] = None
 
 class TryOnResult(BaseModel):
     product_id: int
     product_name: str
+    product_description: Optional[str] = None
+    product_price: Optional[str] = None
     result_image: Optional[str] = None
     error: Optional[str] = None
     status: str  # 'success' | 'failed'

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,5 +1,13 @@
+from .email_service import EmailService
+from .fake_service import FakeService
 from .fashn_service import FashnService
 from .gemini_service import GeminiService
 from .tryon_service import TryOnService
 
-__all__ = ["FashnService", "GeminiService", "TryOnService"]
+__all__ = [
+    "EmailService",
+    "FakeService",
+    "FashnService",
+    "GeminiService",
+    "TryOnService",
+]

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -1,0 +1,128 @@
+"""Service utilitaire pour l'envoi de résumés d'essayage virtuel."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import smtplib
+from email.message import EmailMessage
+from typing import Dict, Union
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+TryOnResultPayload = Dict[str, Union[str, int, None]]
+
+
+class EmailService:
+    """Service responsable de l'envoi des e-mails de synthèse."""
+
+    def __init__(self) -> None:
+        self.smtp_host = settings.smtp_host
+        self.smtp_port = settings.smtp_port
+        self.smtp_username = settings.smtp_username
+        self.smtp_password = settings.smtp_password
+        self.smtp_sender = settings.smtp_sender
+        self.smtp_use_tls = settings.smtp_use_tls
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self.smtp_host and self.smtp_sender)
+
+    async def send_summary(
+        self,
+        to_email: str,
+        person_image_url: str,
+        results: Dict[str, TryOnResultPayload],
+    ) -> None:
+        """Envoie un e-mail contenant le résumé des résultats."""
+
+        if not self.is_configured:
+            logger.info("SMTP non configuré. Envoi de l'email ignoré.")
+            return
+
+        message = EmailMessage()
+        message["Subject"] = "Résumé de votre session d'essayage virtuel"
+        message["From"] = self.smtp_sender
+        message["To"] = to_email
+
+        text_content = self._build_text_content(results)
+        html_content = self._build_html_content(person_image_url, results)
+
+        message.set_content(text_content)
+        message.add_alternative(html_content, subtype="html")
+
+        await asyncio.to_thread(self._send_email, message)
+
+    def _send_email(self, message: EmailMessage) -> None:
+        try:
+            with smtplib.SMTP(self.smtp_host, self.smtp_port, timeout=30) as server:
+                if self.smtp_use_tls:
+                    server.starttls()
+                if self.smtp_username and self.smtp_password:
+                    server.login(self.smtp_username, self.smtp_password)
+                server.send_message(message)
+        except Exception as exc:
+            logger.error("Échec de l'envoi de l'email de résumé: %s", exc)
+
+    def _build_text_content(self, results: Dict[str, TryOnResultPayload]) -> str:
+        lines = [
+            "Bonjour,",
+            "",
+            "Voici le résumé de votre session d'essayage virtuel:",
+            "",
+        ]
+
+        for payload in results.values():
+            name = payload.get("product_name") or "Produit"
+            description = payload.get("product_description") or "Description non disponible"
+            price_value = payload.get("product_price")
+            price = str(price_value) if price_value else ""
+
+            lines.append(f"- {name}")
+            lines.append(f"  Description : {description}")
+            if price:
+                lines.append(f"  Prix : {price}")
+            lines.append("")
+
+        lines.append("À bientôt pour un nouvel essayage !")
+        return "\n".join(lines)
+
+    def _build_html_content(
+        self,
+        person_image_url: str,
+        results: Dict[str, TryOnResultPayload],
+    ) -> str:
+        items_html = []
+        for payload in results.values():
+            name = payload.get("product_name") or "Produit"
+            description = payload.get("product_description") or "Description non disponible"
+            price_value = payload.get("product_price")
+            price = str(price_value) if price_value else ""
+            result_image = payload.get("result_image") or person_image_url
+
+            product_html = f"""
+                <div style='margin-bottom:24px;'>
+                    <h3 style='margin:0 0 8px 0;font-family:Arial,sans-serif;color:#111;'>{name}</h3>
+                    <img src='{result_image}' alt='{name}' style='width:240px;border-radius:8px;display:block;margin-bottom:8px;' />
+                    <p style='margin:0 0 4px 0;font-family:Arial,sans-serif;color:#444;'>{description}</p>
+            """
+            if price:
+                product_html += f"<p style='margin:0;font-family:Arial,sans-serif;color:#666;'>Prix : {price}</p>"
+            product_html += "</div>"
+            items_html.append(product_html)
+
+        items_markup = "".join(items_html)
+
+        return f"""
+            <html>
+                <body style='font-family:Arial,sans-serif;background-color:#f8f8f8;padding:24px;'>
+                    <div style='max-width:600px;margin:0 auto;background:#ffffff;padding:24px;border-radius:12px;'>
+                        <h2 style='margin-top:0;color:#111;'>Résumé de votre session d'essayage virtuel</h2>
+                        <p style='color:#444;'>Merci d'avoir utilisé notre service d'essayage virtuel. Voici vos looks générés :</p>
+                        {items_markup}
+                        <p style='color:#666;'>À très vite pour un nouvel essayage !</p>
+                    </div>
+                </body>
+            </html>
+        """

--- a/backend/app/services/fake_service.py
+++ b/backend/app/services/fake_service.py
@@ -1,0 +1,73 @@
+"""Service factice pour simuler un appel à une API d'essayage virtuel."""
+from __future__ import annotations
+
+import asyncio
+from typing import Dict, List, Optional, Union
+
+from app.schemas.tryon import ProductInfo
+
+ProductInfoLike = Union[ProductInfo, Dict[str, Union[str, int, None]]]
+
+
+class FakeService:
+    """Simule les résultats d'un service d'essayage virtuel externe."""
+
+    async def generate_results(
+        self,
+        person_image_url: str,
+        product_ids: List[int],
+        products_info: Optional[List[ProductInfoLike]] = None,
+    ) -> Dict[str, Dict[str, Union[str, int, None]]]:
+        """Génère des résultats factices après un délai simulé."""
+
+        await asyncio.sleep(min(1.0 + len(product_ids) * 0.5, 4.0))
+
+        info_map: Dict[int, ProductInfoLike] = {}
+        if products_info:
+            for item in products_info:
+                raw_id = getattr(item, "id", None)
+                if raw_id is None and isinstance(item, dict):
+                    raw_id = item.get("id")
+                if raw_id is None:
+                    continue
+
+                try:
+                    product_id = int(raw_id)  # type: ignore[arg-type]
+                except (TypeError, ValueError):
+                    continue
+
+                info_map[product_id] = item
+
+        results: Dict[str, Dict[str, Union[str, int, None]]] = {}
+        for product_id in product_ids:
+            info = info_map.get(product_id)
+            name: Optional[str] = None
+            description: Optional[str] = None
+            price: Optional[str] = None
+
+            if info is not None:
+                if isinstance(info, ProductInfo):
+                    name = info.name
+                    description = getattr(info, "description", None)
+                    price = info.price
+                else:
+                    name = info.get("name")  # type: ignore[assignment]
+                    description = info.get("description")  # type: ignore[assignment]
+                    price = info.get("price")  # type: ignore[assignment]
+
+            if not name:
+                name = f"Produit #{product_id}"
+
+            if price is not None:
+                price = str(price)
+
+            results[f"product_{product_id}"] = {
+                "product_id": product_id,
+                "product_name": name,
+                "product_description": description,
+                "product_price": price,
+                "result_image": person_image_url,
+                "status": "success",
+            }
+
+        return results

--- a/backend/app/services/tryon_service.py
+++ b/backend/app/services/tryon_service.py
@@ -1,82 +1,109 @@
-from typing import Dict, Any, List
-from app.schemas.tryon import TryOnRequest, TryOnResponse
-import uuid
+"""Service principal gérant les sessions d'essayage virtuel."""
+from __future__ import annotations
+
 import asyncio
+import uuid
+from typing import Any, Dict, Optional
+
+from app.schemas.tryon import TryOnRequest, TryOnResponse
+from app.services.email_service import EmailService
+from app.services.fake_service import FakeService
+
 
 class TryOnService:
-    def __init__(self):
-        pass
+    """Orchestre les sessions d'essayage virtuel et leur suivi."""
 
-    async def process_try_on(
-        self, 
-        request: TryOnRequest
-    ) -> TryOnResponse:
-        """Traiter un essayage virtuel"""
-        
-        # Générer un ID de session si non fourni
-        session_id = request.session_id or str(uuid.uuid4())
-        
-        # Valider les données d'entrée
-        if not request.product_ids or len(request.product_ids) == 0:
-            return TryOnResponse(
-                session_id=session_id,
-                status="failed",
-                message="Aucun produit sélectionné"
-            )
-        
+    _sessions: Dict[str, Dict[str, Any]] = {}
+
+    def __init__(
+        self,
+        fake_service: Optional[FakeService] = None,
+        email_service: Optional[EmailService] = None,
+    ) -> None:
+        self.fake_service = fake_service or FakeService()
+        self.email_service = email_service or EmailService()
+
+    async def process_try_on(self, request: TryOnRequest) -> TryOnResponse:
+        """Initialise une nouvelle session d'essayage virtuel."""
+
+        if not request.product_ids:
+            raise ValueError("Aucun produit sélectionné")
+
         if not request.person_image_url:
-            return TryOnResponse(
-                session_id=session_id,
-                status="failed",
-                message="Aucune image de personne fournie"
-            )
-        
-        # Simuler un délai de traitement basé sur le nombre de produits
-        processing_delay = min(1 + len(request.product_ids) * 0.2, 3)  # Max 3 secondes
-        await asyncio.sleep(processing_delay)
-        
-        # Retourner une réponse de traitement en cours
+            raise ValueError("Aucune image de personne fournie")
+
+        session_id = request.session_id or str(uuid.uuid4())
+        request_with_session = request.model_copy(update={"session_id": session_id})
+
+        message = (
+            f"Essayage virtuel en cours de traitement pour {len(request.product_ids)} produit(s)..."
+        )
+
+        loop = asyncio.get_running_loop()
+        self._sessions[session_id] = {
+            "request": request_with_session,
+            "status": "processing",
+            "message": message,
+            "results": None,
+            "error_message": None,
+            "created_at": loop.time(),
+        }
+
+        processing_delay = min(1.0 + len(request.product_ids) * 0.2, 4.0)
+        asyncio.create_task(self._simulate_processing(session_id, processing_delay))
+
         return TryOnResponse(
             session_id=session_id,
             status="processing",
-            message=f"Essayage virtuel en cours de traitement pour {len(request.product_ids)} produit(s)..."
+            message=message,
         )
 
-    async def get_try_on_status(
-        self, 
-        session_id: str
-    ) -> Dict[str, Any]:
-        """Récupérer le statut d'un essayage virtuel"""
-        
-        # Simuler un délai de traitement
-        await asyncio.sleep(2)
-        
-        # Pour la démo, créer des résultats réalistes
-        # En production, vous récupéreriez les vraies données depuis la base
-        fake_results = {
-            "product_1": {
-                "product_id": 1,
-                "product_name": "T-shirt Premium",
-                "result_image": "https://images.unsplash.com/photo-1594633312681-425c7b97ccd1?w=400&h=600&fit=crop&sig=1",
-                "status": "success"
-            },
-            "product_2": {
-                "product_id": 2,
-                "product_name": "Pantalon Élégant",
-                "result_image": "https://images.unsplash.com/photo-1594633312681-425c7b97ccd1?w=400&h=600&fit=crop&sig=2",
-                "status": "success"
-            },
-            "product_3": {
-                "product_id": 3,
-                "product_name": "Veste Moderne",
-                "result_image": "https://images.unsplash.com/photo-1594633312681-425c7b97ccd1?w=400&h=600&fit=crop&sig=3",
-                "status": "success"
-            }
-        }
-        
+    async def _simulate_processing(self, session_id: str, delay: float) -> None:
+        session = self._sessions.get(session_id)
+        if not session:
+            return
+
+        request: TryOnRequest = session["request"]
+        await asyncio.sleep(delay)
+
+        try:
+            results = await self.fake_service.generate_results(
+                person_image_url=request.person_image_url,
+                product_ids=request.product_ids,
+                products_info=request.products_info,
+            )
+            session["results"] = results
+            session["status"] = "completed"
+            session["message"] = (
+                f"Essayage virtuel terminé avec succès - {len(results)} résultat(s)"
+            )
+            session["error_message"] = None
+
+            if request.email:
+                await self.email_service.send_summary(
+                    to_email=request.email,
+                    person_image_url=request.person_image_url,
+                    results=results,
+                )
+        except Exception as exc:  # pragma: no cover - log en cas d'échec
+            session["status"] = "failed"
+            session["message"] = (
+                "Une erreur est survenue pendant le traitement de l'essayage virtuel."
+            )
+            session["error_message"] = str(exc)
+
+    async def get_try_on_status(self, session_id: str) -> Dict[str, Any]:
+        """Retourne l'état actuel d'une session d'essayage."""
+
+        session = self._sessions.get(session_id)
+        if not session:
+            raise KeyError("Session not found")
+
         return {
             "session_id": session_id,
-            "status": "completed",
-            "results": fake_results,
-            "message": f"Essayage virtuel terminé avec succès - {len(fake_results)} résultat(s)"
+            "status": session.get("status", "processing"),
+            "results": session.get("results"),
+            "message": session.get("message", ""),
+            "error_message": session.get("error_message"),
         }
+*** End File

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -1,4 +1,3 @@
-import { cn } from "@/lib/utils";
 import { Check } from "lucide-react";
 
 interface Product {

--- a/frontend/src/pages/LoadingScreen.tsx
+++ b/frontend/src/pages/LoadingScreen.tsx
@@ -2,16 +2,18 @@ import { useEffect, useState, useRef } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { Loader2 } from "lucide-react";
 import { createTryOn, waitForTryOnCompletion } from "@/services/tryOnService";
+import { useAuthStore } from "@/store/useAuthStore";
 
 export default function LoadingScreen() {
   const [progress, setProgress] = useState(0);
   const [status, setStatus] = useState("Initialisation...");
   const [isProcessing, setIsProcessing] = useState(false);
   const hasStartedRef = useRef(false);
-  
+
   const navigate = useNavigate();
   const location = useLocation();
   const { selectedProducts, productConfigs, personImage } = location.state || {};
+  const userEmail = useAuthStore((state) => state.user?.email);
 
   useEffect(() => {
     if (hasStartedRef.current || isProcessing) {
@@ -35,18 +37,20 @@ export default function LoadingScreen() {
         setProgress(20);
         setStatus("Préparation des données...");
         
-        const products_info = productConfigs?.map(config => ({
+        const products_info = productConfigs?.map((config: any) => ({
           id: parseInt(config.id),
           name: config.name,
           price: config.price,
-          image_url: config.displayImage
+          image_url: config.displayImage,
+          description: config.description,
         })) || [];
-        
+
         const tryOnRequest = {
           person_image_url: personImage,
           product_ids: selectedProducts,
           products_info: products_info,
-          session_id: `session_${Date.now()}`
+          session_id: `session_${Date.now()}`,
+          email: userEmail || undefined
         };
 
         setProgress(30);

--- a/frontend/src/pages/ProductSelection.tsx
+++ b/frontend/src/pages/ProductSelection.tsx
@@ -81,6 +81,7 @@ export default function ProductSelection() {
         price: `${p.price.toFixed(2)} €`,
         displayImage: p.image_url,
         apiImage: p.api_image_url || p.image_url,
+        description: p.description || '',
       }));
 
       navigate("/selfie-capture", {

--- a/frontend/src/pages/SelfieCapture.tsx
+++ b/frontend/src/pages/SelfieCapture.tsx
@@ -2,11 +2,9 @@ import { useState, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft, Camera, Upload } from "lucide-react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { cn } from "@/lib/utils";
 
 export default function SelfieCapture() {
   const [capturedImage, setCapturedImage] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -206,6 +204,11 @@ export default function SelfieCapture() {
                     <div className="flex-1 min-w-0">
                       <p className="text-sm font-medium text-foreground truncate">{product.name}</p>
                       <p className="text-xs text-text-subtle">{product.price}</p>
+                      {product.description && (
+                        <p className="text-xs text-text-subtle mt-1 line-clamp-2">
+                          {product.description}
+                        </p>
+                      )}
                     </div>
                   </div>
                 ))}

--- a/frontend/src/pages/VirtualFitting.tsx
+++ b/frontend/src/pages/VirtualFitting.tsx
@@ -11,7 +11,7 @@ export default function VirtualFitting() {
   
   const navigate = useNavigate();
   const location = useLocation();
-  const { selectedProducts, productConfigs, personImage, results, sessionId } = location.state || {};
+  const { personImage, results, sessionId } = location.state || {};
 
   useEffect(() => {
     if (!hasLoggedRef.current) {
@@ -113,7 +113,12 @@ export default function VirtualFitting() {
                 <h3 className="font-medium text-foreground text-base mb-3 line-clamp-2">
                   {result.product_name}
                 </h3>
-                
+                {result.product_description && (
+                  <p className="text-sm text-text-subtle mb-3 line-clamp-2">
+                    {result.product_description}
+                  </p>
+                )}
+
                 <div className="flex gap-2">
                   <Button
                     variant="ghost"

--- a/frontend/src/services/tryOnService.ts
+++ b/frontend/src/services/tryOnService.ts
@@ -5,6 +5,7 @@ export interface ProductInfo {
   name: string;
   price: string;
   image_url: string;
+  description?: string;
 }
 
 export interface TryOnRequest {
@@ -12,11 +13,14 @@ export interface TryOnRequest {
   product_ids: number[];
   products_info?: ProductInfo[];
   session_id?: string;
+  email?: string;
 }
 
 export interface TryOnResult {
   product_id: number;
   product_name: string;
+  product_description?: string;
+  product_price?: string;
   result_image?: string;
   error?: string;
   status: 'success' | 'failed';

--- a/frontend/src/store/useTryOnStore.ts
+++ b/frontend/src/store/useTryOnStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
-import { TryOnResponse, TryOnResult, TryOnSession } from '@/types';
-import { createTryOn, createBatchTryOn, getSessionStatus, getUserSessions } from '@/services/tryOnService';
+import { TryOnResponse, TryOnSession } from '@/types';
+import { createTryOn, getTryOnStatus } from '@/services/tryOnService';
 
 interface TryOnState {
   currentSession: TryOnResponse | null;
@@ -16,9 +16,7 @@ interface TryOnState {
 
 interface TryOnActions {
   createTryOn: (personImageUrl: string, productIds: number[]) => Promise<void>;
-  createBatchTryOn: (personImageUrl: string, productIds: number[], maxConcurrent?: number) => Promise<void>;
   getSessionStatus: (sessionId: string) => Promise<void>;
-  loadUserSessions: () => Promise<void>;
   setProcessing: (processing: boolean) => void;
   setProgress: (current: number, total: number, currentItem?: string) => void;
   setError: (error: string | null) => void;
@@ -27,7 +25,7 @@ interface TryOnActions {
 
 type TryOnStore = TryOnState & TryOnActions;
 
-export const useTryOnStore = create<TryOnStore>((set, get) => ({
+export const useTryOnStore = create<TryOnStore>((set) => ({
   // État initial
   currentSession: null,
   sessions: [],
@@ -56,42 +54,10 @@ export const useTryOnStore = create<TryOnStore>((set, get) => ({
     }
   },
 
-  createBatchTryOn: async (personImageUrl: string, productIds: number[], maxConcurrent: number = 3) => {
-    set({ 
-      isProcessing: true, 
-      error: null,
-      progress: { current: 0, total: productIds.length }
-    });
-    
-    try {
-      const response = await createBatchTryOn(
-        personImageUrl,
-        productIds,
-        maxConcurrent
-      );
-      
-      set({
-        currentSession: {
-          session_id: response.session_id,
-          status: response.status,
-          results: response.results,
-          error_message: response.error_message,
-        },
-        isProcessing: false,
-        progress: { current: productIds.length, total: productIds.length },
-      });
-    } catch (error) {
-      set({
-        error: error instanceof Error ? error.message : 'Erreur lors de la création des essayages',
-        isProcessing: false,
-      });
-    }
-  },
-
   getSessionStatus: async (sessionId: string) => {
     try {
-      const session = await getSessionStatus(sessionId);
-      
+      const session = await getTryOnStatus(sessionId);
+
       set({
         currentSession: {
           session_id: session.session_id,
@@ -104,15 +70,6 @@ export const useTryOnStore = create<TryOnStore>((set, get) => ({
       set({
         error: error instanceof Error ? error.message : 'Erreur lors de la récupération du statut',
       });
-    }
-  },
-
-  loadUserSessions: async () => {
-    try {
-      const sessions = await getUserSessions();
-      set({ sessions });
-    } catch (error) {
-      console.error('Erreur lors du chargement des sessions:', error);
     }
   },
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -38,16 +38,28 @@ export interface Token {
   token_type: string;
 }
 
+export interface ProductInfoSummary {
+  id: number;
+  name: string;
+  price: string;
+  image_url: string;
+  description?: string;
+}
+
 // Types pour les essayages virtuels
 export interface TryOnRequest {
   person_image_url: string;
   product_ids: number[];
   session_id?: string;
+  products_info?: ProductInfoSummary[];
+  email?: string;
 }
 
 export interface TryOnResult {
   product_id: number;
   product_name: string;
+  product_description?: string;
+  product_price?: string;
   result_image?: string;
   error?: string;
   status: 'success' | 'failed';


### PR DESCRIPTION
## Summary
- add a FakeService and EmailService to orchestrate simulated try-on sessions and optional email recaps
- rework the try-on API, schemas, and settings to store richer result data and expose SMTP configuration
- update the frontend flow to send the user email, surface product descriptions, and display result details

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9d1f5d9f08327895a4475f0cc519d